### PR TITLE
Update version format to comply with specs

### DIFF
--- a/Src/Extensions/bhce-okta-extension.json
+++ b/Src/Extensions/bhce-okta-extension.json
@@ -2,7 +2,7 @@
   "schema": {
     "name": "OktaHound",
     "display_name": "Okta (OktaHound)",
-    "version": "2.8.0",
+    "version": "v2.8.0",
     "namespace": "Okta"
   },
   "node_kinds": [


### PR DESCRIPTION
Version number needs to be prepended by a `v`